### PR TITLE
AUTHORS.md: clarify roles

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,8 +1,8 @@
 The development of VIT was made possible by the significant
 contributions of the following people:
 
+ * Chad Phillips      (Original Author >= 2.x)
  * Scott Kostyshak    (Maintainer and Contributing Author)
- * Chad Phillips      (Original 2.x Author)
  * Steve Rader        (Original Author)
  * Paul Beckingham    (Advisor)
  * David J Patrick    (Designer)


### PR DESCRIPTION
@thehunmonkgroup 
Chad, what do you think of these changes? Additionally, it seems strange for me to have the role of "Maintainer" since you are currently doing more maintaining that I am. Either we should add "Maintainer" to your role or subtract it from mine. I don't have a preference which.