### PR TITLE
handle reports w/o columns info. "timesheets" for me doesn't.

### DIFF
--- a/vit/config_parser.py
+++ b/vit/config_parser.py
@@ -343,6 +343,8 @@ class TaskParser(object):
         return primary_sort[0] == 'project' and primary_sort[1] == 'ascending'
 
     def get_column_index(self, report_name, column):
+        if not 'columns' in self.reports[report_name]:
+            return None
         return self.reports[report_name]['columns'].index(column) if column in self.reports[report_name]['columns'] else None
 
     def get_column_label(self, report_name, column):


### PR DESCRIPTION
Might only be needed with latest taskwarrior 2.5.2, not sure, and wasn't sure if this was best way to handle it.

If nothing else, heads-up in case you encounter this down the road! :)

Thanks for all your work, BTW! I think the revived vit might be a key player in my return to taskwarrior goodness!

