### PR TITLE
[2.x] Correct import

### DIFF
--- a/vit/option_parser.py
+++ b/vit/option_parser.py
@@ -45,8 +45,8 @@ def format_dictionary_list(item, description):
     print("\t%s\n" % description)
 
 def list_actions():
-    from registry import ActionRegistry
-    from actions import Actions
+    from vit.registry import ActionRegistry
+    from vit.actions import Actions
     action_registry = ActionRegistry()
     actions = Actions(action_registry)
     actions.register()


### PR DESCRIPTION
Caught this when I ran `vit --list-actions` here on Fedora. I think these are the only instances, but worth a check in an installed environment (outside the source tree).