### PR TITLE
fix #176: Readline edit shortcuts for command bar

### DIFF
--- a/vit/command_bar.py
+++ b/vit/command_bar.py
@@ -1,4 +1,5 @@
 import urwid
+from vit.readline import Readline
 
 class CommandBar(urwid.Edit):
     """Custom urwid.Edit class for the command bar.
@@ -8,6 +9,7 @@ class CommandBar(urwid.Edit):
         self.autocomplete = kwargs['autocomplete']
         self.metadata = None
         self.history = CommandBarHistory()
+        self.readline = Readline(self)
         kwargs.pop('event')
         kwargs.pop('autocomplete')
         return super().__init__(**kwargs)
@@ -15,7 +17,6 @@ class CommandBar(urwid.Edit):
     def keypress(self, size, key):
         """Overrides Edit.keypress method.
         """
-        # TODO: Readline edit shortcuts.
         if key not in ('tab', 'shift tab'):
             self.autocomplete.deactivate()
         if 'choices' in self.metadata:
@@ -29,21 +30,11 @@ class CommandBar(urwid.Edit):
             self.cleanup(op)
             self.event.emit('command-bar:keypress', data)
             return None
-        elif key in ('ctrl a',):
-            self.set_edit_pos(0)
+        elif key in ('up',):
+            self.readline.keypress('ctrl p')
             return None
-        elif key in ('ctrl e',):
-            self.set_edit_pos(len(self.get_edit_text()))
-            return None
-        elif key in ('up', 'ctrl p'):
-            text = self.history.previous(self.metadata['history'])
-            if text != False:
-                self.set_edit_text(text)
-            return None
-        elif key in ('down', 'ctrl n'):
-            text = self.history.next(self.metadata['history'])
-            if text != False:
-                self.set_edit_text(text)
+        elif key in ('down',):
+            self.readline.keypress('ctrl n')
             return None
         elif key in ('enter', 'esc'):
             text = self.get_edit_text().strip()
@@ -66,6 +57,8 @@ class CommandBar(urwid.Edit):
                     kwargs['reverse'] = True
                 self.autocomplete.activate(text, self.edit_pos, **kwargs)
             return None
+        elif key in self.readline.keys():
+            return self.readline.keypress(key)
         return super().keypress(size, key)
 
     def is_autocomplete_op(self):

--- a/vit/readline.py
+++ b/vit/readline.py
@@ -1,0 +1,133 @@
+import string
+import re
+
+class Readline(object):
+    def __init__(self, edit_obj):
+        self.edit_obj = edit_obj
+        word_chars = string.ascii_letters + string.digits + "_"
+        self._word_regex1 = re.compile(
+            "([%s]+)" % "|".join(re.escape(ch) for ch in word_chars)
+        )
+        self._word_regex2 = re.compile(
+            "([^%s]+)" % "|".join(re.escape(ch) for ch in word_chars)
+        )
+
+    def keys(self):
+        return ('ctrl p', 'ctrl n', 'ctrl a', 'ctrl e', 'ctrl b', 'ctrl f',
+                'ctrl h', 'ctrl d', 'ctrl t', 'ctrl u', 'ctrl k', 'meta b',
+                'meta f', 'ctrl w', 'meta d')
+
+    def keypress(self, key):
+        # Move to the previous line.
+        if key in ('ctrl p',):
+            text = self.edit_obj.history.previous(self.edit_obj.metadata['history'])
+            if text != False:
+                self.edit_obj.set_edit_text(text)
+            return None
+        # Move to the next line.
+        elif key in ('ctrl n',):
+            text = self.edit_obj.history.next(self.edit_obj.metadata['history'])
+            if text != False:
+                self.edit_obj.set_edit_text(text)
+            return None
+        # Jump to the beginning of the line.
+        elif key in ('ctrl a',):
+            self.edit_obj.set_edit_pos(0)
+            return None
+        # Jump to the end of the line.
+        elif key in ('ctrl e',):
+            self.edit_obj.set_edit_pos(len(self.edit_obj.get_edit_text()))
+            return None
+        # Jump backward one character.
+        elif key in ('ctrl b',):
+            self.edit_obj.set_edit_pos(self.edit_obj.edit_pos - 1)
+            return None
+        # Jump forward one character.
+        elif key in ('ctrl f',):
+            self.edit_obj.set_edit_pos(self.edit_obj.edit_pos + 1)
+            return None
+        # Delete previous character.
+        elif key in ('ctrl h',):
+            if self.edit_obj.edit_pos > 0:
+                self.edit_obj.set_edit_pos(self.edit_obj.edit_pos - 1)
+                self.edit_obj.set_edit_text(
+                    self.edit_obj.get_edit_text()[0 : self.edit_obj.edit_pos]
+                    + self.edit_obj.get_edit_text()[self.edit_obj.edit_pos + 1 :])
+            return None
+        # Delete next character.
+        elif key in ('ctrl d',):
+            if self.edit_obj.edit_pos < len(self.edit_obj.get_edit_text()):
+                edit_pos = self.edit_obj.edit_pos
+                self.edit_obj.set_edit_text(
+                    self.edit_obj.get_edit_text()[0 : self.edit_obj.edit_pos] +
+                    self.edit_obj.get_edit_text()[self.edit_obj.edit_pos + 1 :])
+                self.edit_obj.set_edit_pos(edit_pos)
+            return None
+        # Transpose characters.
+        elif key in ('ctrl t',):
+            # Can't transpose if there are less than 2 chars
+            if len(self.edit_obj.get_edit_text()) < 2:
+                return None
+            self.edit_obj.set_edit_pos(max(2, self.edit_obj.edit_pos + 1))
+            new_edit_pos = self.edit_obj.edit_pos
+
+            edit_text = self.edit_obj.get_edit_text()
+            self.edit_obj.set_edit_text(
+                        edit_text[: new_edit_pos - 2] +
+                        edit_text[new_edit_pos - 1] +
+                        edit_text[new_edit_pos - 2] +
+                        edit_text[new_edit_pos :])
+            self.edit_obj.set_edit_pos(new_edit_pos)
+            return None
+        # Delete backwards to the beginning of the line.
+        elif key in ('ctrl u',):
+            self.edit_obj.set_edit_text(self.edit_obj.get_edit_text()[self.edit_obj.edit_pos :])
+            self.edit_obj.set_edit_pos(0)
+            return None
+        # Delete forwards to the end of the line.
+        elif key in ('ctrl k',):
+            self.edit_obj.set_edit_text(self.edit_obj.get_edit_text()[: self.edit_obj.edit_pos])
+            return None
+        # Jump backward one word.
+        elif key in ('meta b',):
+            self.jump_backward_word()
+            return None
+        # Jump forward one word.
+        elif key in ('meta f',):
+            self.jump_forward_word()
+            return None
+        # Delete backwards to the beginning of the current word.
+        elif key in ('ctrl w',):
+            old_edit_pos = self.edit_obj.edit_pos
+            self.jump_backward_word()
+            new_edit_pos = self.edit_obj.edit_pos
+            self.edit_obj.set_edit_text(self.edit_obj.edit_text[: new_edit_pos]
+                + self.edit_obj.edit_text[old_edit_pos :])
+            self.edit_obj.set_edit_pos(new_edit_pos)
+            return None
+        # Delete forwards to the end of the current word.
+        elif key in ('meta d',):
+            edit_pos = self.edit_obj.edit_pos
+            self.jump_forward_word()
+            self.edit_obj.set_edit_text(self.edit_obj.edit_text[: edit_pos]
+                + self.edit_obj.edit_text[self.edit_obj.edit_pos :])
+            self.edit_obj.set_edit_pos(edit_pos)
+            return None
+
+    def jump_backward_word(self):
+        for match in self._word_regex1.finditer(
+            self.edit_obj.edit_text[: self.edit_obj.edit_pos][::-1]
+        ):
+            self.edit_obj.set_edit_pos(self.edit_obj.edit_pos - match.end(1))
+            return
+        self.edit_obj.set_edit_pos(0)
+
+    def jump_forward_word(self):
+        for match in self._word_regex2.finditer(
+            self.edit_obj.edit_text[self.edit_obj.edit_pos :]
+        ):
+            if match.start(1) > 0:
+                self.edit_obj.set_edit_pos(self.edit_obj.edit_pos + match.start(1))
+                return
+        self.edit_obj.set_edit_pos(len(self.edit_obj.edit_text))
+


### PR DESCRIPTION
New available readline commands are: Ctrl+b, Ctrl+f, Ctrl+h, Ctrl+d,
Ctrl+t, Ctrl+u, Ctrl+k, Meta+b, Meta+f, Ctrl+w, Meta+d.

These changes were based on [urwid readline](https://github.com/rr-/urwid_readline) where possible.
The code was adapted in places where urwid readline acted differently than expected from readline, e.g. in urwid, Meta+f jumped to the start of the next word, instead of the end of the current word.

Also, explicit reference to internal variables as used in urwid readline were exchanged by setter functions and normal variables (e.g. instead of using `self._edit_pos`, use `self.edit_pos` to get and `self.set_edit_pos()` to set). I'd really like feedback on this as I'm not sure what is the right thing to do here.