### PR TITLE
Allows config option value to contain '='

### DIFF
--- a/vit/config_parser.py
+++ b/vit/config_parser.py
@@ -209,7 +209,7 @@ class TaskParser(object):
         if returncode == 0:
             lines = list(filter(lambda x: True if x else False, stdout.split("\n")))
             for line in lines:
-                hierarchy, values = line.split('=')
+                hierarchy, values = line.split('=', maxsplit=1)
                 self.task_config.append((hierarchy, values))
         else:
             raise RuntimeError('Error parsing task config: %s' % stderr)


### PR DESCRIPTION
I have the following alias in my config:

```
alias.open=execute bash -l -x -c "q=($BASH_COMMAND); taskopen \\"\\\\${q[-1]}\\""
```

Taskwarrior works fine with this. If I try to launch vit, I get:

```
Traceback (most recent call last):
  File "/usr/bin/vit", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python3.7/site-packages/vit/command_line.py", line 5, in main
    Application(options, filters)
  File "/usr/lib/python3.7/site-packages/vit/application.py", line 70, in __init__
    self.load_early_config()
  File "/usr/lib/python3.7/site-packages/vit/application.py", line 78, in load_early_config
    self.task_config = TaskParser(self.config)
  File "/usr/lib/python3.7/site-packages/vit/config_parser.py", line 197, in __init__
    self.get_task_config()
  File "/usr/lib/python3.7/site-packages/vit/config_parser.py", line 209, in get_task_config
    hierarchy, values = line.split('=')
ValueError: too many values to unpack (expected 2)
```