### PR TITLE
README.md: remove reference to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Visual Interactive Taskwarrior full-screen terminal interface.
 
-*For VIT 1.3, [visit here](https://github.com/scottkosty/vit/tree/1.3)*
-
 ## Features
 
  * Fully-customizable key bindings *(default Vim-like)*


### PR DESCRIPTION
@thehunmonkgroup I think we linked to 1.3 after we made 2.x the default branch, but I think the transition to 2.x is complete and smooth. Please merge if you agree.