### PR TITLE
catch re compile errors to prevent crashing

### DIFF
--- a/vit/application.py
+++ b/vit/application.py
@@ -478,14 +478,20 @@ class Application():
         self.table.batcher.add(0)
         self.search_display_message(reverse)
         current_index = 0 if self.task_list.focus is None else self.task_list.focus_position
-        new_focus = self.search_rows(self.search_term_active, current_index, reverse)
-        if new_focus is None:
-            self.activate_message_bar("Pattern not found: %s" % self.search_term_active, 'error')
-        else:
-            self.task_list.focus_position = new_focus
+        try:
+            new_focus = self.search_rows(self.search_term_active, current_index, reverse)
+            if new_focus is None:
+                self.activate_message_bar("Pattern not found: %s" % self.search_term_active, 'error')
+            else:
+                self.task_list.focus_position = new_focus
+        except ValueError as e:
+            self.activate_message_bar(str(e), 'error')
 
     def search_rows(self, term, start_index=0, reverse=False):
-        search_regex = re.compile(term, re.MULTILINE)
+        try:
+            search_regex = re.compile(term, re.MULTILINE)
+        except:
+            raise ValueError("Invalid regex: %s" % term)
         rows = self.table.rows
         current_index = start_index
         last_index = len(rows) - 1

--- a/vit/help.py
+++ b/vit/help.py
@@ -110,7 +110,10 @@ class Help(object):
 
     def filter_entries(self, filter_args):
         if len(filter_args) > 0:
-            args_regex = re.compile('.*(%s).*' % '|'.join(filter_args))
+            try:
+                args_regex = re.compile('.*(%s).*' % '|'.join(filter_args))
+            except:
+                return []
             return [(section, keys, description) for section, keys, description, search_phrase in self.entries if args_regex.match(search_phrase)]
         else:
             return [(section, keys, description) for section, keys, description, _ in self.entries]


### PR DESCRIPTION
vit crashes when you enter `/+foo`, as it's an invalid regex. I was originally trying to search for a tag when vit crashed. This PR catches the exception and shows a regex error.

I noticed a similar issue with `:help +foo`, hope you don't mind both changes in 1 PR.

Note: I don't see a test suite for the `vit.Application` class, and there's a lot of wiring needed to setup a test instance.