### PR TITLE
Allow doing multiple task selection to modify them all at once

### DIFF
--- a/vit/actions.py
+++ b/vit/actions.py
@@ -46,6 +46,7 @@ class Actions(object):
         self.action_registrar.register('TASK_WAIT', 'Wait a task')
         self.action_registrar.register('TASK_EDIT', 'Edit a task via the default editor')
         self.action_registrar.register('TASK_SHOW', 'Show task details')
+        self.action_registrar.register('TASK_SELECT', 'Select a task which can be later used by Modify')
 
     def get(self):
         return self.action_registry.actions

--- a/vit/keybinding/vi.ini
+++ b/vit/keybinding/vi.ini
@@ -30,6 +30,8 @@ p = {ACTION_TASK_PROJECT}
 T = {ACTION_TASK_TAGS}
 w = {ACTION_TASK_WAIT}
 e = {ACTION_TASK_EDIT}
+v = {ACTION_TASK_SELECT}
+
 # The parser will not allow an equals sign on the left side of an assignment,
 # the special <Equals> marker is used instead.
 <Enter>,<Equals> = {ACTION_TASK_SHOW}

--- a/vit/task_list.py
+++ b/vit/task_list.py
@@ -20,7 +20,7 @@ MARKER_COLUMN_NAME = 'markers'
 
 class TaskTable(object):
 
-    def __init__(self, config, task_config, formatter, screen, on_select=None, event=None, action_manager=None, request_reply=None, markers=None, draw_screen_callback=None):
+    def __init__(self, config, task_config, formatter, screen, on_select=None, event=None, action_manager=None, request_reply=None, markers=None, draw_screen_callback=None, selected_tasks=None):
         self.config = config
         self.task_config = task_config
         self.formatter = formatter
@@ -36,10 +36,13 @@ class TaskTable(object):
         self.listbox = TaskListBox(self.list_walker, self.screen, event=self.event, request_reply=self.request_reply, action_manager=self.action_manager)
         self.init_event_listeners()
         self.set_request_callbacks()
+        self.selected_tasks = selected_tasks
 
     def init_event_listeners(self):
         def signal_handler():
             self.update_focus()
+            self.update_selection()
+
         urwid.connect_signal(self.list_walker, 'modified', signal_handler)
         def task_list_keypress(data):
             self.update_header(data['size'])
@@ -150,6 +153,12 @@ class TaskTable(object):
         if position is None:
             position = self.listbox.focus_position
         self.list_walker[position].row.set_attr_map({None: attr})
+
+    def update_selection(self):
+        selected_task_ids = set([task['id'] for task in self.selected_tasks])
+        for item in self.list_walker:
+            if item.id in selected_task_ids:
+                item.row.set_attr_map({None: 'reveal select'})
 
     def flash_focus(self, repeat_times=2, pause_seconds=0.1):
         if self.listbox.focus:

--- a/vit/theme/classic.py
+++ b/vit/theme/classic.py
@@ -4,6 +4,7 @@ theme = [
     ('list-header-column-separator', '', '', '', '', ''),
     ('striped-table-row', 'white', 'dark gray', '', 'white', 'g27'),
     ('reveal focus', 'white', 'dark blue', 'standout', 'white', 'dark blue'),
+    ('reveal select', 'white', 'dark red', 'standout', 'white', 'dark red'),
     ('message status', '', '', '', '', ''),
     ('message error', 'white', 'dark red', 'standout', 'white', 'dark red'),
     ('status', 'dark blue', 'black', '', 'dark blue', 'black'),

--- a/vit/theme/default.py
+++ b/vit/theme/default.py
@@ -4,6 +4,7 @@ theme = [
     ('list-header-column-separator', 'black', 'light gray', '', 'black', 'light gray'),
     ('striped-table-row', 'white', 'dark gray', '', 'white', 'g27'),
     ('reveal focus', 'black', 'dark cyan', 'standout', 'black', 'dark cyan'),
+    ('reveal select', 'black', 'dark red', 'standout', 'black', 'dark red'),
     ('message status', 'white', 'dark blue', 'standout', 'white', 'dark blue'),
     ('message error', 'white', 'dark red', 'standout', 'white', 'dark red'),
     ('status', 'dark magenta', 'black', '', 'dark magenta', 'black'),


### PR DESCRIPTION
Hi,

This patch adds two things

1) Add a new select command, which allows users to select tasks by pressing `v`. 
2) When using the modify command (`m`), when there are multiple tasks selected, it'll execute the command against all selected tasks. 

Let me know how you think about the patch and please feel free to reject it because I was basically just hacking around :)
