### PR TITLE
Add default keybindings for jumping to task number

### DIFF
--- a/vit/keybinding/vi.ini
+++ b/vit/keybinding/vi.ini
@@ -48,6 +48,16 @@ M = {ACTION_LIST_SCREEN_MIDDLE}
 L = {ACTION_LIST_SCREEN_BOTTOM}
 C = {ACTION_LIST_FOCUS_VALIGN_CENTER}
 
+1 = :1
+2 = :2
+3 = :3
+4 = :4
+5 = :5
+6 = :6
+7 = :7
+8 = :8
+9 = :9
+
 [report]
 f = {ACTION_REPORT_FILTER}
 <Ctrl>l = {ACTION_REFRESH}


### PR DESCRIPTION
Since none of the numbers have default keybindings at the moment, and since apparently vit doesn't support prepending a command with a count like vim, assign default keybindings to each digit that opens an ex command with the digit.

This is just for convenience, so that the user that wants to jump to task 123 can just type `123`, instead of `:123`. Just one keystroke saved, but a free one.

This isn't really the `vim`-way to do things, this binding is actually the default in `mutt`, but since `vi.ini` seemed to be the only file for default keybindings, I added it here. We could add it to a different file if it is possible to source both at startup by default.