### PR TITLE
Add 'abort_backspace' config, False by default.

### DIFF
--- a/vit/application.py
+++ b/vit/application.py
@@ -562,7 +562,8 @@ class Application():
         self.autocomplete = AutoComplete(self.config, extra_filters={'report': self.reports.keys(), 'help': self.help.autocomplete_entries(), 'context': context_list})
 
     def init_command_bar(self):
-        self.command_bar = CommandBar(autocomplete=self.autocomplete, event=self.event)
+        abort_backspace = self.config.get('vit', 'abort_backspace')
+        self.command_bar = CommandBar(autocomplete=self.autocomplete, abort_backspace=abort_backspace, event=self.event)
 
     def build_frame(self):
         self.status_report = urwid.AttrMap(urwid.Text('Welcome to VIT'), 'status')

--- a/vit/config/config.sample.ini
+++ b/vit/config/config.sample.ini
@@ -50,6 +50,9 @@
 # list items.
 #mouse = False
 
+# Boolean. If true, hitting backspace against an empty prompt aborts the prompt.
+#abort_backspace = False
+
 [report]
 
 # The default Taskwarrior report to load when VIT first starts, if no report

--- a/vit/config_parser.py
+++ b/vit/config_parser.py
@@ -44,6 +44,7 @@ DEFAULTS = {
         'confirmation': True,
         'wait': True,
         'mouse': False,
+        'abort_backspace': False,
     },
     'report': {
         'default_report': 'next',


### PR DESCRIPTION
If true, hitting backspace against an empty prompt aborts the prompt.

Resolves https://github.com/vit-project/vit/issues/274