### PR TITLE
Add support for {*_FILTER} keybinding replacements (refs #240)

### DIFF
--- a/vit/application.py
+++ b/vit/application.py
@@ -199,10 +199,49 @@ class Application():
                     return str(task[attribute])
             return ''
 
+        # currently active filter lookup functions. all of these return the
+        # internally used filter representation, which is a flat list of strings
+        _extra_filter = lambda: self.extra_filters
+        _report_filter = lambda: self.model.active_report_filter()
+        _context_filter = lambda: self.active_context_filter()
+
+        # _view_filter is simply a concat of these three filters. logical 'and' is
+        # implied by taskwarrior, just need to make sure to preserve the internal
+        # precedence within each of the three sub-filters
+        def _protect_precedence(filter):
+            return ['(', *filter, ')'] if len(filter) > 1 else filter
+        def _view_filter():
+            parts = [ _extra_filter(), _report_filter(), _context_filter() ]
+            # filter out empty parts
+            parts = [ part for part in parts if part ]
+            # if there is more than one non-empty filter, and at least one part
+            # potentially has complex internal precedence structure...
+            if len(parts) > 1 and any([ len(part) > 1 for part in parts ]):
+                # ..then add parens around all complex parts
+                parts = [ _protect_precedence(part) for part in parts ]
+            return [ item for sublist in parts for item in sublist ]
+
+        _filter_replacements = {
+            'EXTRA_FILTER': _extra_filter,
+            'REPORT_FILTER': _report_filter,
+            'CONTEXT_FILTER': _context_filter,
+            'VIEW_FILTER': _view_filter,
+        }
+        def _filter_attribute_match(variable):
+            if variable in _filter_replacements:
+                return [variable]
+        def _filter_attribute_replace(task, variable):
+            # get filter resolution function and execute it, return as string
+            return ' '.join(_filter_replacements.get(variable)())
+
         replacements = [
             {
                 'match_callback': _task_attribute_match,
                 'replacement_callback': _task_attribute_replace,
+            },
+            {
+                'match_callback': _filter_attribute_match,
+                'replacement_callback': _filter_attribute_replace,
             },
         ]
         return replacements

--- a/vit/application.py
+++ b/vit/application.py
@@ -97,6 +97,9 @@ class Application():
     def set_active_context(self):
         self.context = self.task_config.get_active_context()
 
+    def active_context_filter(self):
+        return self.contexts[self.context]['filter'] if self.context else []
+
     def load_contexts(self):
         self.contexts = self.task_config.get_contexts()
 
@@ -195,6 +198,7 @@ class Application():
                 else:
                     return str(task[attribute])
             return ''
+
         replacements = [
             {
                 'match_callback': _task_attribute_match,
@@ -909,7 +913,7 @@ class Application():
         self.task_config.get_projects()
         self.refresh_blocking_task_uuids()
         self.formatter.recalculate_due_datetimes()
-        context_filters = self.contexts[self.context]['filter'] if self.context else []
+        context_filters = self.active_context_filter()
         try:
             self.model.update_report(self.report, context_filters=context_filters, extra_filters=self.extra_filters)
         except VitException as err:

--- a/vit/task.py
+++ b/vit/task.py
@@ -33,8 +33,7 @@ class TaskListModel(object):
 
     def update_report(self, report, context_filters=[], extra_filters=[]):
         self.report = report
-        active_report = self.active_report()
-        report_filters = active_report['filter'] if 'filter' in active_report else []
+        report_filters = self.active_report_filter()
         filters = self.build_task_filters(context_filters, report_filters, extra_filters)
         try:
             self.tasks = self.tw.tasks.filter(filters) if filters else self.tw.tasks.all()
@@ -44,6 +43,10 @@ class TaskListModel(object):
             len(self.tasks)
         except TaskWarriorException as err:
             raise VitException(self.parse_error(err))
+
+    def active_report_filter(self):
+        active_report = self.active_report()
+        return active_report['filter'] if 'filter' in active_report else []
 
     def build_task_filters(self, *all_filters):
         def reducer(accum, filters):


### PR DESCRIPTION
This pull request adds support for 4 new keybinding replacement variables, each of which resolves to `task` filter expressions that underly the currently visible list of tasks displayed by vit:

* `{EXTRA_FILTER}`: any extra filter expression applied by the user
* `{REPORT_FILTER}`: the `report.___.filter` of the currently visible report
* `{CONTEXT_FILTER}`: filter expression of the currently active context
* `{VIEW_FILTER}`: this is just a concatenation of the other three which preserves internal precedence by adding parentheses (if necessary)

## Testing

The easiest way to test the correctness of the replacements is by adding the following keybinding (change the actual key to your liking): `G = :all {VIEW_FILTER}`
Now open any report in any context in vit and apply any extra filters. By invoking the binding you can first inspect the correctness of the filter expression, when you confirm it you will end up at the `all` report showing the exact same tasks as the view that you just came from (tasks shown and tasks completed in the status bar should be the same as well). Repeatedly invoking the binding will just bring you back to the same report with the same filter applied over and over again.