### PR TITLE
Add support for 'waiting' task status marker

### DIFF
--- a/vit/config/config.sample.ini
+++ b/vit/config/config.sample.ini
@@ -141,6 +141,8 @@
 #uda.label =
 #uda.priority.label = (PR)
 #uda.[uda_name].label =
+#until.label = (U)
+#waiting.label = (W)
 
 
 [color]

--- a/vit/formatter/markers.py
+++ b/vit/formatter/markers.py
@@ -92,7 +92,7 @@ class Markers(Marker):
         return self.add_label(color, label, width, text_markup)
 
     def format_status(self, width, text_markup, status):
-        if status == 'completed' or status == 'deleted':
+        if status == 'completed' or status == 'deleted' or status == 'waiting':
             color = self.colorizer.status(status)
             label = self.labels['%s.label' % status]
             return self.add_label(color, label, width, text_markup)

--- a/vit/markers.py
+++ b/vit/markers.py
@@ -31,6 +31,7 @@ LABEL_DEFAULTS = {
     'uda.label': '',
     'uda.priority.label': '(PR)',
     'until.label': '(U)',
+    'waiting.label': '(W)',
 }
 
 class Markers(object):


### PR DESCRIPTION
This PR adds a marker for 'waiting' tasks, one of the 5 mutually exclusive task states which was previously not supported for marking.

Just for sake of completeness, here is the current support for marking of tasks in each of the 5 possible states:
* [X] `completed` already supported (determined via task `status`)
* [X] `deleted` already supported (determined via task `status`)
* [X] `waiting` implemented by this pull request (also determined via task `status`)
* [X] `recurring` already supported but internally this is done by checking the `recur` field, rather than the `status` (a task's `status` is `recurring` iff the task has a `recur:` date): https://github.com/vit-project/vit/blob/1d59db8fd4aa6dddd275e4551806e8fa33357896/vit/formatter/markers.py#L20-L21)
* [ ] `pending` tasks can't currently be marked, but this is sort of the default/'unmarked' state of tasks so possibly superfluous to add support for a marker for it?