### PR TITLE
Fix 307 - Vit ignoring 'report.X.context=0' option

### DIFF
--- a/vit/application.py
+++ b/vit/application.py
@@ -922,7 +922,7 @@ class Application():
         self.task_config.get_projects()
         self.refresh_blocking_task_uuids()
         self.formatter.recalculate_due_datetimes()
-        context_filters = self.contexts[self.context]['filter'] if self.context else []
+        context_filters = self.contexts[self.context]['filter'] if self.context and self.reports[self.report].get('context', 1) else []
         try:
             self.model.update_report(self.report, context_filters=context_filters, extra_filters=self.extra_filters)
         except VitException as err:

--- a/vit/config_parser.py
+++ b/vit/config_parser.py
@@ -362,6 +362,8 @@ class TaskParser(object):
         }
         if 'columns' in attrs:
           reports[report]['columns'] = attrs['columns'].split(',')
+        if 'context' in attrs:
+          reports[report]['context'] = int(attrs['context'])
         if 'description' in attrs:
           reports[report]['description'] = attrs['description']
         if 'filter' in attrs:


### PR DESCRIPTION
As mentioned in #307 Taskwarrior 2.6.0 introduced a new option 'report.X.context'. If set to 0 the respective report should ignore all filters set by the current context.

This PR tries to fix this missing feature within VIT.

I tested this fix with TW 2.6.0 and the dummy install attached to #307 but it should also be backwards compatible (please someone test this with an older TW version).