### PR TITLE
Escape search term

### DIFF
--- a/vit/application.py
+++ b/vit/application.py
@@ -492,7 +492,8 @@ class Application():
             self.task_list.focus_position = new_focus
 
     def search_rows(self, term, start_index=0, reverse=False):
-        search_regex = re.compile(term, re.MULTILINE)
+        escaped_term = re.escape(term)
+        search_regex = re.compile(escaped_term, re.MULTILINE)
         rows = self.table.rows
         current_index = start_index
         last_index = len(rows) - 1


### PR DESCRIPTION
Sometimes my tasks start with a special character or I just I click by mistake `?` twice during reverse search - now vit crashes, when search term contains starts with regex special chars. For example, searching with "?" will crash vit. 

This little change fixes that.