### PR TITLE
Allow flash configuration

### DIFF
--- a/vit/config/config.sample.ini
+++ b/vit/config/config.sample.ini
@@ -69,6 +69,12 @@
 #   /tmp/vit_pids
 #pid_dir =
 
+# Int. The number of flash repetitions focusing on the edit made
+#flash_focus_repeat_times = 2
+
+# Float. Waiting time for the blink focusing on the edit made
+#flash_focus_pause_seconds = 0.1
+
 [report]
 
 # The default Taskwarrior report to load when VIT first starts, if no report

--- a/vit/config_parser.py
+++ b/vit/config_parser.py
@@ -47,6 +47,8 @@ DEFAULTS = {
         'abort_backspace': False,
         'focus_on_add': False,
         'pid_dir': '',
+        'flash_focus_repeat_times': 2,
+        'flash_focus_pause_seconds': 0.1,
     },
     'report': {
         'default_report': 'next',
@@ -166,7 +168,7 @@ configuration.
         try:
             value = self.config.get(section, key)
             return self.transform(key, value, default)
-        except (configparser.NoSectionError, configparser.NoOptionError):
+        except (configparser.NoSectionError, configparser.NoOptionError, ValueError):
             return default
 
     def items(self, section):
@@ -181,11 +183,21 @@ configuration.
     def transform(self, key, value, default):
         if isinstance(default, bool):
             return self.transform_bool(value)
+        elif isinstance(default, int):
+            return self.transform_int(value)
+        elif isinstance(default, float):
+            return self.transform_float(value)
         else:
             return value
 
     def transform_bool(self, value):
         return True if CONFIG_BOOLEAN_TRUE_REGEX.match(value) else False
+
+    def transform_int(self, value):
+        return int(value)
+
+    def transform_float(self, value):
+        return float(value)
 
     def get_taskrc_path(self):
         taskrc_path = os.path.expanduser('TASKRC' in env.user and env.user['TASKRC'] or self.get('taskwarrior', 'taskrc'))
@@ -211,6 +223,12 @@ configuration.
 
     def is_mouse_enabled(self):
         return self.get('vit', 'mouse')
+
+    def get_flash_focus_repeat_times(self):
+        return self.get('vit', 'flash_focus_repeat_times')
+
+    def get_flash_focus_pause_seconds(self):
+        return self.get('vit', 'flash_focus_pause_seconds')
 
 class TaskParser(object):
     def __init__(self, config):

--- a/vit/task_list.py
+++ b/vit/task_list.py
@@ -153,10 +153,14 @@ class TaskTable(object):
             position = self.listbox.focus_position
         self.list_walker[position].row.set_attr_map({None: attr})
 
-    def flash_focus(self, repeat_times=2, pause_seconds=0.1):
+    def flash_focus(self, repeat_times=None, pause_seconds=None):
+        if repeat_times is None:
+            repeat_times = self.config.get_flash_focus_repeat_times()
+        if pause_seconds is None:
+            pause_seconds = self.config.get_flash_focus_pause_seconds()
         if self.listbox.focus:
             position = self.listbox.focus_position if self.listbox.focus_position is not None else self.listbox.previous_focus_position if self.listbox.previous_focus_position is not None else None
-            if position is not None:
+            if position is not None and repeat_times > 0:
                 self.update_focus_attr('flash on', position)
                 self.draw_screen()
                 for i in repeat(None, repeat_times):


### PR DESCRIPTION
Add 'flash_focus_repeat_times' and 'flash_focus_pause_seconds' keys to [vit] section in config.ini. Also support int and float types in config and automatically parse (transform) them. Keep same default values.

fixes vit-project/vit#270