### PR TITLE
Make `$XDG_CONFIG_HOME/vit` the new default `vit` config location

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -8,9 +8,11 @@ VIT provides a user directory that allows for configuring basic settings *(via `
 
 VIT searches for the user directory in this order of priority:
 
-1. The ```VIT_DIR``` environment variable
-2. ```~/.vit``` (the default location)
-3. A ```vit``` directory in any valid [XDG base directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+1. The `VIT_DIR` environment variable
+2. `~/.vit` (the old default location)
+3. `$XDG_CONFIG_HOME/vit`, following the [XDG base directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+
+If no config exists, you'll be prompted to create one (in `$XDG_CONFIG_HOME/vit`).
 
 #### Taskwarrior configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tasklib>=2.4.3
 urwid>=2.1.2
 backports.zoneinfo;python_version<"3.9"
+xdg-base-dirs>=6.0.0

--- a/vit/config_parser.py
+++ b/vit/config_parser.py
@@ -17,7 +17,6 @@ from vit.process import Command
 
 SORT_ORDER_CHARACTERS = ['+', '-']
 SORT_COLLATE_CHARACTERS = ['/']
-VIT_CONFIG_FILE = 'config.ini'
 FILTER_EXCLUSION_REGEX = re.compile(r'^limit:')
 FILTER_PARENS_REGEX = re.compile(r'([\(\)])')
 CONFIG_BOOLEAN_TRUE_REGEX = re.compile(r'1|yes|true', re.IGNORECASE)
@@ -102,15 +101,15 @@ class ConfigParser:
         self.loader = loader
         self.config = configparser.SafeConfigParser()
         self.config.optionxform = str
-        self.user_config_dir = self.loader.user_config_dir
-        self.user_config_filepath = '%s/%s' % (self.user_config_dir, VIT_CONFIG_FILE)
-        if not self.config_file_exists(self.user_config_filepath):
-            self.optional_create_config_file(self.user_config_filepath)
-        self.config.read(self.user_config_filepath)
+        self.vit_config = self.loader.user_config_file
+        if not self.config_file_exists(self.vit_config):
+            self.optional_create_config_file(self.vit_config)
+        self.config.read(self.vit_config)
         self.taskrc_path = self.get_taskrc_path()
         self.validate_taskrc()
         self.defaults = DEFAULTS
         self.set_config_data()
+
 
     def set_config_data(self):
         self.subproject_indentable = self.is_subproject_indentable()
@@ -203,7 +202,7 @@ configuration.
         taskrc_path = os.path.expanduser('TASKRC' in env.user and env.user['TASKRC'] or self.get('taskwarrior', 'taskrc'))
 
         if not os.path.exists(taskrc_path):
-            xdg_dir = xdg.get_xdg_config_dir(taskrc_path, "task")
+            xdg_dir = xdg.check_for_existing_xdg_configs("task")
             if xdg_dir:
                 taskrc_path = os.path.join(xdg_dir, "taskrc")
 

--- a/vit/xdg.py
+++ b/vit/xdg.py
@@ -3,7 +3,7 @@ import os
 from vit import env
 
 
-def get_xdg_config_dir(user_config_dir, resource):
+def check_for_existing_xdg_configs(resource):
     xdg_config_home = env.user.get("XDG_CONFIG_HOME") or os.path.join(
         os.path.expanduser("~"), ".config"
     )


### PR DESCRIPTION
Users will now be prompted to ask if it's ok to create a config dir at `$XDG_CONFIG_HOME/vit` instead of at `~/.vit`. No backwards-compatibility will be broken, as `~/.vit` is still supported.