### PR TITLE
fix(py3.12): `SafeConfigParser` -> `ConfigParser`

### DIFF
--- a/vit/config_parser.py
+++ b/vit/config_parser.py
@@ -100,7 +100,7 @@ DATE_FORMAT_MAPPING = {
 class ConfigParser:
     def __init__(self, loader):
         self.loader = loader
-        self.config = configparser.SafeConfigParser()
+        self.config = configparser.ConfigParser()
         self.config.optionxform = str
         self.user_config_dir = self.loader.user_config_dir
         self.user_config_filepath = '%s/%s' % (self.user_config_dir, VIT_CONFIG_FILE)

--- a/vit/keybinding_parser.py
+++ b/vit/keybinding_parser.py
@@ -31,7 +31,7 @@ class KeybindingParser:
         self.actions = self.action_registry.get_actions()
         self.noop_action_name = self.action_registry.make_action_name(self.action_registry.noop_action_name)
         self.default_keybinding_name = self.config.get('vit', 'default_keybindings')
-        self.default_keybindings = configparser.SafeConfigParser()
+        self.default_keybindings = configparser.ConfigParser()
         self.default_keybindings.optionxform=str
         self.sections = DEFAULT_KEYBINDINGS_SECTIONS
         self.keybindings = {}


### PR DESCRIPTION
`SafeConfigParser` was deprecated in 3.2 and has been removed.

Reference:

https://docs.python.org/3.12/whatsnew/3.12.html#configparser