### PR TITLE
Fixed UDA & priority orders

### DIFF
--- a/vit/task_list.py
+++ b/vit/task_list.py
@@ -177,7 +177,7 @@ class TaskTable:
     def sort(self):
         if 'sort' in self.report:
             for column, order, collate in reversed(self.report['sort']):
-                def comparator(first, second):
+                def comparator_default(first, second):
                     if first[column] is not None and second[column] is not None:
                         return -1 if first[column] < second[column] else 1 if first[column] > second[column] else 0
                     elif first[column] is None and second[column] is None:
@@ -186,6 +186,20 @@ class TaskTable:
                         return -1
                     elif first[column] is None and second[column] is not None:
                         return 1
+
+                def comparator_uda_string(values_index, first, second):
+                    a, b = first[column], second[column]
+                    default_index = len(values_index)
+                    a_index = values_index.get(a or '', default_index)
+                    b_index = values_index.get(b or '', default_index)
+                    return (a_index > b_index) - (a_index < b_index)
+
+                uda = self.task_config.uda_config.get(column)
+                if uda != None and uda.get('type') == 'string':
+                    values_index = uda.get('values_index')
+                    comparator = partial(comparator_uda_string, values_index)
+                else:
+                    comparator = comparator_default
                 if order and order == 'descending':
                     self.tasks = sorted(self.tasks, key=cmp_to_key(comparator), reverse=True)
                 else:

--- a/vit/task_list.py
+++ b/vit/task_list.py
@@ -195,7 +195,7 @@ class TaskTable:
                     return (a_index > b_index) - (a_index < b_index)
 
                 uda = self.task_config.uda_config.get(column)
-                if uda != None and uda.get('type') == 'string':
+                if uda is not None and uda.get('type') == 'string':
                     values_index = uda.get('values_index')
                     comparator = partial(comparator_uda_string, values_index)
                 else:


### PR DESCRIPTION
Consider priority and UDA orders in taskrc, such as `uda.priority.values = H,M,L,`.
Note that this only works if the UDA type is set to string.

taskrc:
```
uda.priority.values = H,M,L,
# uda.priority.type = string

report.list.sort = priority+
```

Before:
<img width="376" alt="before" src="https://github.com/user-attachments/assets/db4134a2-4d69-4cc2-890f-75c474bbad14" />
H -> L -> M (Wrong... Alphabetically...)

After:
<img width="376" alt="after" src="https://github.com/user-attachments/assets/4fbc5494-6516-408f-aed8-c0425818e386" />
H -> M -> L (Correct !)

This is my first pull request on GitHub.
Please let me know if there are any issues or if I've made any mistakes.