### PR TITLE
Add RawText markup support for escape sequences with safe width and search handling

### DIFF
--- a/vit/application.py
+++ b/vit/application.py
@@ -38,6 +38,7 @@ from vit.registry import ActionRegistry, RequestReply
 from vit.action_manager import ActionManagerRegistry
 from vit.denotation import DenotationPopupLauncher
 from vit.pid_manager import PidManager
+from vit.markup import markup_to_str
 
 # NOTE: This entire class is a workaround for the fact that urwid catches the
 # 'ctrl l' keypress in its unhandled_input code, and prevents that from being
@@ -571,9 +572,7 @@ class Application:
         self.search_display_message(reverse)
 
     def reconstitute_markup_element_as_string(self, accum, markup):
-        if isinstance(markup, tuple):
-            _, markup = markup
-        return accum + markup
+        return accum + markup_to_str(markup)
 
     def reconstitute_markup_as_string(self, markup):
         if isinstance(markup, list):

--- a/vit/markup.py
+++ b/vit/markup.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from urwid.util import calc_width
+
+
+@dataclass(frozen=True)
+class RawText:
+    data: bytes
+
+
+def markup_contains_raw(markup) -> bool:
+    if isinstance(markup, RawText):
+        return True
+    if isinstance(markup, list):
+        return any(markup_contains_raw(item) for item in markup)
+    if isinstance(markup, tuple):
+        _, inner = markup
+        return markup_contains_raw(inner)
+    return False
+
+
+def markup_to_bytes(markup, encoding: str = "utf-8"):
+    if isinstance(markup, RawText):
+        return markup.data
+    if isinstance(markup, bytes):
+        return markup
+    if isinstance(markup, str):
+        return markup.encode(encoding)
+    if isinstance(markup, list):
+        return [markup_to_bytes(item, encoding=encoding) for item in markup]
+    if isinstance(markup, tuple):
+        attr, inner = markup
+        return (attr, markup_to_bytes(inner, encoding=encoding))
+    return markup
+
+
+def normalize_markup(markup, encoding: str = "utf-8"):
+    if markup_contains_raw(markup):
+        return markup_to_bytes(markup, encoding=encoding)
+    return markup
+
+
+def markup_display_width(markup) -> int:
+    if markup is None:
+        return 0
+    if isinstance(markup, RawText):
+        return 0
+    if isinstance(markup, list):
+        return sum(markup_display_width(item) for item in markup)
+    if isinstance(markup, tuple):
+        _, inner = markup
+        return markup_display_width(inner)
+    if isinstance(markup, (str, bytes)):
+        return calc_width(markup, 0, len(markup))
+    return 0
+
+
+def markup_to_str(markup, encoding: str = "utf-8") -> str:
+    if markup is None:
+        return ""
+    if isinstance(markup, RawText):
+        return ""
+    if isinstance(markup, bytes):
+        return markup.decode(encoding, errors="ignore")
+    if isinstance(markup, str):
+        return markup
+    if isinstance(markup, list):
+        return "".join(markup_to_str(item, encoding=encoding) for item in markup)
+    if isinstance(markup, tuple):
+        _, inner = markup
+        return markup_to_str(inner, encoding=encoding)
+    return ""

--- a/vit/task_list.py
+++ b/vit/task_list.py
@@ -14,6 +14,7 @@ from vit.base_list_box import BaseListBox
 from vit.list_batcher import ListBatcher
 from vit.formatter.project import Project as ProjectFormatter
 from vit.util import unicode_len
+from vit.markup import normalize_markup, markup_display_width
 
 
 REDUCE_COLUMN_WIDTH_LIMIT = 20
@@ -266,10 +267,12 @@ class TaskTable:
 
     def build_row_column(self, formatted_value):
         if isinstance(formatted_value, tuple):
-            return formatted_value
+            width, text_markup = formatted_value
+            return width, normalize_markup(text_markup)
         else:
-            width = unicode_len(formatted_value) if formatted_value else 0
-            return width, formatted_value
+            text_markup = normalize_markup(formatted_value)
+            width = markup_display_width(text_markup) if formatted_value else 0
+            return width, text_markup
 
     def subproject_indentable(self):
         return self.config.subproject_indentable and self.report['subproject_indentable']


### PR DESCRIPTION
### Motivation

This change introduces a small, generic markup layer so VIT can carry raw terminal escape sequences (like OSC‑8 hyperlinks) without corrupting them or letting them affect layout sizing. That makes it possible for custom formatters to inject clickable links in supported terminals (e.g., WezTerm) while keeping column widths and search behavior stable.

### What Changed

New `vit/markup.py` helper module with:

`RawText` — a tiny wrapper for raw byte sequences (e.g., OSC‑8)

`normalize_markup()` — converts markup containing RawText into byte-safe markup for urwid

`markup_display_width()` — computes visible width while ignoring RawText

`markup_to_str()` — reconstructs a search-safe string from markup, ignoring RawText

Task table rendering now normalizes markup and uses `markup_display_width()` for column sizing.

Search string reconstruction is now robust to mixed str/bytes/RawText markup.

### Why This Matters

Before this, any control sequence embedded in a description would be encoded with replacement by urwid, producing `?]8;;...` instead of a real hyperlink. By exposing a `RawText` container, formatter authors can inject raw OSC‑8 sequences safely without breaking layout or search.

### Example: Custom Description Formatter with OSC‑8 Links

Below is a minimal example formatter that turns Jira-style prefixes into clickable terminal hyperlinks. Save as `~/.vit/formatters/description.py`:

```python
from vit.formatter import String
from vit.util import unicode_len
from vit.markup import RawText

JIRA_URL = "https://someurl.com/browse/"

class Description(String):
    def format(self, description, task):
        if not description:
            return self.empty()

        # Parse prefix like "ABC-123: something"
        try:
            jira_id, rest = description.split(":", 1)
        except ValueError:
            # fall back to normal behavior
            width = unicode_len(description)
            return (width, self.colorize_description(description))

        # OSC-8 hyperlink sequence (ESC ] 8 ;; URL BEL ... ESC ] 8 ;; BEL)
        link_start = RawText(f"\x1b]8;;{JIRA_URL}{jira_id}\x07".encode("utf-8"))
        link_end = RawText(b"\x1b]8;;\x07")

        # Build visible text using markup with RawText
        visible = f"{jira_id}:{rest}"
        colorized = self.colorize_description(visible)

        # Prepend the raw hyperlink markers around the Jira ID
        # This keeps the visible text unchanged but makes the ID clickable.
        colorized[0] = (
            colorized[0][0],
            link_start,
        )
        colorized.insert(1, (None, f"{jira_id}"))
        colorized.insert(2, (None, link_end))
        colorized.insert(3, (None, f":{rest}"))

        width = unicode_len(visible)
        if task["annotations"]:
            annotation_width, colorized = self.format_combined(colorized, task)
            width = max(width, annotation_width)

        return (width, colorized)
```

**NOTE: The code changes and example code were generated by Codex. I did review the code that would be committed to VIT, and it seems solid, however, I did not verify the example override, or if the code added to VIT would work as expected -- this will need to be verified by someone prior to merge**