### PR TITLE
Guard empty autocomplete tab options

### DIFF
--- a/vit/autocomplete.py
+++ b/vit/autocomplete.py
@@ -252,6 +252,9 @@ class AutoComplete:
         return len(self.tab_options) - 1 if reverse else 0
 
     def increment_index(self, reverse):
+        if len(self.tab_options) == 0:
+            self.idx = None
+            return
         if self.idx == None:
             self.idx = self.initial_idx(reverse)
         else:
@@ -264,6 +267,9 @@ class AutoComplete:
         tabbed_text = ''
         edit_pos = None
         if self.root_search:
+            if len(self.tab_options) == 0:
+                self.deactivate()
+                return text, None
             self.increment_index(reverse)
             tabbed_text = self.tab_options[self.idx]
         else:
@@ -280,4 +286,3 @@ class AutoComplete:
                     self.increment_index(reverse)
                     tabbed_text, edit_pos = self.assemble(self.tab_options[self.idx])
         return tabbed_text, edit_pos
-


### PR DESCRIPTION
### Motivation

- Prevent crashes when autocomplete has no tab options by avoiding index access in that case.
- Ensure `increment_index` does not compute or wrap an index when `self.tab_options` is empty.
- Reset autocomplete state for an empty root-search so subsequent interactions start from a clean state.

### Description

- Added a guard at the start of `increment_index` to set `self.idx = None` and return when `len(self.tab_options) == 0` in `vit/autocomplete.py`.
- Added a guard in the `self.root_search` branch of `next_tab_item` to call `self.deactivate()` and return the original `text, None` when `self.tab_options` is empty.
- Kept existing tab-selection behavior unchanged for non-empty `tab_options`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963e789f0a08332a1a772125eebfd21)