### PR TITLE
Add `grey*` aliases for Urwid color mapping

### DIFF
--- a/test/test_color_mappings.py
+++ b/test/test_color_mappings.py
@@ -1,0 +1,20 @@
+import unittest
+
+from vit.color_mappings import task_256_to_urwid_256
+
+
+class TestColorMappings(unittest.TestCase):
+
+    def test_maps_gray_and_grey_base_name(self):
+        mapping = task_256_to_urwid_256()
+        self.assertEqual(mapping['gray'], 'light gray')
+        self.assertEqual(mapping['grey'], 'light gray')
+
+    def test_maps_grey_scale_variants(self):
+        mapping = task_256_to_urwid_256()
+        self.assertEqual(mapping['gray10'], mapping['grey10'])
+        self.assertEqual(mapping['grey10'], 'g40')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vit/color_mappings.py
+++ b/vit/color_mappings.py
@@ -9,6 +9,7 @@ def task_256_to_urwid_256():
         'cyan': 'dark cyan',
         'magenta': 'dark magenta',
         'gray': 'light gray',
+        'grey': 'light gray',
         'yellow': 'brown',
         'color0': 'black',
         'color1': 'dark red',
@@ -52,10 +53,12 @@ def task_color_gray_to_g():
     color_map = {}
     for i in range(0, 24):
         gray_key = 'gray%d' % i
+        grey_key = 'grey%d' % i
         color_key = 'color%d' % (i + 232)
         # NOTE: This is an approximation of the conversion, close enough!
         value = 'g%d' % (i * 4)
         color_map[gray_key] = value
+        color_map[grey_key] = value
         color_map[color_key] = value
     return color_map
 


### PR DESCRIPTION
Crashes were occurring because `grey*` isn’t remapped before Urwid palette registration; the existing logic only handled `gray*` spellings. This change adds a compatibility layer by introducing `grey` and `grey0..grey23` aliases to the existing color mapping path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b9d2ee673c83328a9dae827e302906)